### PR TITLE
feature/estatisticas-eventos

### DIFF
--- a/src/modules/events/dto/event-stats.dto.ts
+++ b/src/modules/events/dto/event-stats.dto.ts
@@ -1,12 +1,34 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, Min } from 'class-validator';
+
 export class EventStatsDto {
-    
-    @ApiProperty({ description: 'Total de eventos cadastrados', example: 10 })
-    total: number;
-    @ApiProperty({ description: 'Quantidade de eventos no período da manhã (06:00 - 11:59)', example: 3 })
-    matutino: number;
-    @ApiProperty({ description: 'Quantidade de eventos no período da tarde (12:00 - 17:59)', example: 3 })
-    vespertino: number;
-    @ApiProperty({ description: 'Quantidade de eventos no período da noite/madrugada (18:00 - 05:59)', example: 4 })
-    noturno: number;
+  @ApiProperty({ description: 'Total de eventos cadastrados', example: 10 })
+  @IsInt()
+  @Min(0)
+  readonly total: number;
+
+  @ApiProperty({
+    description: 'Quantidade de eventos no período da manhã (06:00 - 11:59)',
+    example: 3,
+  })
+  @IsInt()
+  @Min(0)
+  readonly matutino: number;
+
+  @ApiProperty({
+    description: 'Quantidade de eventos no período da tarde (12:00 - 17:59)',
+    example: 3,
+  })
+  @IsInt()
+  @Min(0)
+  readonly vespertino: number;
+
+  @ApiProperty({
+    description:
+      'Quantidade de eventos no período da noite/madrugada (18:00 - 05:59)',
+    example: 4,
+  })
+  @IsInt()
+  @Min(0)
+  readonly noturno: number;
 }

--- a/src/modules/events/dto/event-stats.dto.ts
+++ b/src/modules/events/dto/event-stats.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+export class EventStatsDto {
+    
+    @ApiProperty({ description: 'Total de eventos cadastrados', example: 10 })
+    total: number;
+    @ApiProperty({ description: 'Quantidade de eventos no período da manhã (06:00 - 11:59)', example: 3 })
+    matutino: number;
+    @ApiProperty({ description: 'Quantidade de eventos no período da tarde (12:00 - 17:59)', example: 3 })
+    vespertino: number;
+    @ApiProperty({ description: 'Quantidade de eventos no período da noite/madrugada (18:00 - 05:59)', example: 4 })
+    noturno: number;
+}

--- a/src/modules/events/dto/find-all-events.dto.ts
+++ b/src/modules/events/dto/find-all-events.dto.ts
@@ -1,5 +1,5 @@
-import { IsEnum, IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
-import { Type, Transform } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type, Transform, TransformFnParams } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class FindAllEventsDto {
@@ -29,17 +29,19 @@ export class FindAllEventsDto {
   @ApiPropertyOptional({ description: 'Busca eventos por termo ou descrição' })
   @IsOptional()
   @IsString()
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @Transform(({ value }: TransformFnParams): string => {
+    return typeof value === 'string' ? value.trim() : String(value);
+  })
   search?: string;
 
   @ApiPropertyOptional({
     description: 'Filtra eventos pelo período do dia',
-    enum: ['matutino', 'vespertino', 'noturno']
+    enum: ['matutino', 'vespertino', 'noturno'],
   })
   @IsOptional()
   @IsString()
   @IsIn(['matutino', 'vespertino', 'noturno'], {
-    message: 'Período inválido. Use: matutino, vespertino ou noturno'
+    message: 'Período inválido. Use: matutino, vespertino ou noturno',
   })
   periodo?: 'matutino' | 'vespertino' | 'noturno';
 }

--- a/src/modules/events/dto/find-all-events.dto.ts
+++ b/src/modules/events/dto/find-all-events.dto.ts
@@ -1,10 +1,10 @@
-import { IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsEnum, IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class FindAllEventsDto {
   @IsOptional()
-  @Type(() => Number) // Garante que "1" vire o número 1
+  @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
@@ -13,7 +13,7 @@ export class FindAllEventsDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
-  @Max(50) // Proteção contra sobrecarga
+  @Max(50)
   limit?: number = 9;
 
   @IsOptional()
@@ -31,4 +31,15 @@ export class FindAllEventsDto {
   @IsString()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   search?: string;
+
+  @ApiPropertyOptional({ 
+    description: 'Filtra eventos pelo período do dia',
+    enum: ['matutino', 'vespertino', 'noturno'] 
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['matutino', 'vespertino', 'noturno'], { 
+    message: 'Período inválido. Use: matutino, vespertino ou noturno' 
+  })
+  periodo?: 'matutino' | 'vespertino' | 'noturno';
 }

--- a/src/modules/events/dto/find-all-events.dto.ts
+++ b/src/modules/events/dto/find-all-events.dto.ts
@@ -32,14 +32,14 @@ export class FindAllEventsDto {
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   search?: string;
 
-  @ApiPropertyOptional({ 
+  @ApiPropertyOptional({
     description: 'Filtra eventos pelo período do dia',
-    enum: ['matutino', 'vespertino', 'noturno'] 
+    enum: ['matutino', 'vespertino', 'noturno']
   })
   @IsOptional()
   @IsString()
-  @IsIn(['matutino', 'vespertino', 'noturno'], { 
-    message: 'Período inválido. Use: matutino, vespertino ou noturno' 
+  @IsIn(['matutino', 'vespertino', 'noturno'], {
+    message: 'Período inválido. Use: matutino, vespertino ou noturno'
   })
   periodo?: 'matutino' | 'vespertino' | 'noturno';
 }

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -29,7 +29,7 @@ import { EventStatsDto } from './dto/event-stats.dto';
 @ApiTags('events')
 @Controller('events')
 export class EventsController {
-  constructor(private readonly eventsService: EventsService) { }
+  constructor(private readonly eventsService: EventsService) {}
 
   @Post()
   @ApiOperation({ summary: 'Create a new event' })
@@ -46,17 +46,23 @@ export class EventsController {
 
   @Get()
   @ApiOperation({ summary: 'List all events with sorting options' })
-  @ApiResponse({ status: 200, description: 'List of all events', type: [Event] })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all events',
+    type: [Event],
+  })
   findAll(@Query() query: FindAllEventsDto): PaginatedResult<Event> {
     return this.eventsService.findAll(query);
   }
 
   @Get('stats')
-  @ApiOperation({ summary: 'Obter estatísticas consolidadas dos eventos por período' })
+  @ApiOperation({
+    summary: 'Obter estatísticas consolidadas dos eventos por período',
+  })
   @ApiResponse({
     status: 200,
     description: 'Estatísticas retornadas com sucesso.',
-    type: EventStatsDto
+    type: EventStatsDto,
   })
   getStats(): EventStatsDto {
     return this.eventsService.getStats();

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -24,11 +24,12 @@ import { CreateEventDto, UpdateEventDto } from './dto';
 import { Event } from './entities/event.entity';
 import { FindAllEventsDto } from './dto/find-all-events.dto';
 import type { PaginatedResult } from '../../common/interfaces/pagination.interface';
+import { EventStatsDto } from './dto/event-stats.dto';
 
 @ApiTags('events')
 @Controller('events')
 export class EventsController {
-  constructor(private readonly eventsService: EventsService) {}
+  constructor(private readonly eventsService: EventsService) { }
 
   @Post()
   @ApiOperation({ summary: 'Create a new event' })
@@ -43,11 +44,22 @@ export class EventsController {
     return this.eventsService.create(createEventDto);
   }
 
-@Get()
+  @Get()
   @ApiOperation({ summary: 'List all events with sorting options' })
   @ApiResponse({ status: 200, description: 'List of all events', type: [Event] })
-  findAll(@Query() query: FindAllEventsDto) : PaginatedResult<Event> {
+  findAll(@Query() query: FindAllEventsDto): PaginatedResult<Event> {
     return this.eventsService.findAll(query);
+  }
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Obter estatísticas consolidadas dos eventos por período' })
+  @ApiResponse({
+    status: 200,
+    description: 'Estatísticas retornadas com sucesso.',
+    type: EventStatsDto
+  })
+  getStats(): EventStatsDto {
+    return this.eventsService.getStats();
   }
 
   @Get(':id')

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -28,14 +28,24 @@ export class EventsService {
   }
 
   findAll(query: FindAllEventsDto = {}): PaginatedResult<Event> {
-    const { page = 1, limit = 9, sort = 'date', order = 'asc', search, periodo } = query;
+    const {
+      page = 1,
+      limit = 9,
+      sort = 'date',
+      order = 'asc',
+      search,
+      periodo,
+    } = query;
     let eventsToProcess = this.events;
 
     if (search) {
       const termoBusca = search.toLowerCase();
       eventsToProcess = eventsToProcess.filter((event) => {
-        const matchName = event.name && event.name.toLowerCase().includes(termoBusca);
-        const matchDesc = event.description && event.description.toLowerCase().includes(termoBusca);
+        const matchName =
+          event.name && event.name.toLowerCase().includes(termoBusca);
+        const matchDesc =
+          event.description &&
+          event.description.toLowerCase().includes(termoBusca);
         return matchName || matchDesc;
       });
     }
@@ -125,7 +135,7 @@ export class EventsService {
 
         return stats;
       },
-      { total: 0, matutino: 0, vespertino: 0, noturno: 0 }
+      { total: 0, matutino: 0, vespertino: 0, noturno: 0 },
     );
   }
 

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -27,7 +27,7 @@ export class EventsService {
   }
 
   findAll(query: FindAllEventsDto = {}): PaginatedResult<Event> {
-    const { page = 1, limit = 9, sort = 'date', order = 'asc', search } = query;
+    const { page = 1, limit = 9, sort = 'date', order = 'asc', search, periodo } = query;
     let eventsToProcess = this.events;
 
 if (search) {
@@ -38,6 +38,18 @@ if (search) {
     return matchName || matchDesc;
   });
 }
+
+if (periodo) {
+      eventsToProcess = eventsToProcess.filter((event) => {
+        const hora = new Date(event.date).getHours();
+        
+        if (periodo === 'matutino') return hora >= 6 && hora < 12;
+        if (periodo === 'vespertino') return hora >= 12 && hora < 18;
+        if (periodo === 'noturno') return hora >= 18 || hora < 6;
+        
+        return true;
+      });
+    }
 
     const sortedEvents = [...eventsToProcess].sort((a, b) => {
       const valueA = a[sort];

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -4,6 +4,7 @@ import { CreateEventDto, UpdateEventDto } from './dto';
 import { Event } from './entities/event.entity';
 import { FindAllEventsDto } from './dto/find-all-events.dto';
 import { PaginatedResult } from '../../common/interfaces/pagination.interface';
+import { EventStatsDto } from './dto/event-stats.dto';
 
 @Injectable()
 export class EventsService {
@@ -30,23 +31,23 @@ export class EventsService {
     const { page = 1, limit = 9, sort = 'date', order = 'asc', search, periodo } = query;
     let eventsToProcess = this.events;
 
-if (search) {
-  const termoBusca = search.toLowerCase();
-  eventsToProcess = eventsToProcess.filter((event) => {
-    const matchName = event.name && event.name.toLowerCase().includes(termoBusca);
-    const matchDesc = event.description && event.description.toLowerCase().includes(termoBusca);
-    return matchName || matchDesc;
-  });
-}
+    if (search) {
+      const termoBusca = search.toLowerCase();
+      eventsToProcess = eventsToProcess.filter((event) => {
+        const matchName = event.name && event.name.toLowerCase().includes(termoBusca);
+        const matchDesc = event.description && event.description.toLowerCase().includes(termoBusca);
+        return matchName || matchDesc;
+      });
+    }
 
-if (periodo) {
+    if (periodo) {
       eventsToProcess = eventsToProcess.filter((event) => {
         const hora = new Date(event.date).getHours();
-        
+
         if (periodo === 'matutino') return hora >= 6 && hora < 12;
         if (periodo === 'vespertino') return hora >= 12 && hora < 18;
         if (periodo === 'noturno') return hora >= 18 || hora < 6;
-        
+
         return true;
       });
     }
@@ -58,9 +59,9 @@ if (periodo) {
       if (valueA < valueB) return order === 'asc' ? -1 : 1;
       if (valueA > valueB) return order === 'asc' ? 1 : -1;
       return 0;
-      });
-   
-  const total = sortedEvents.length;
+    });
+
+    const total = sortedEvents.length;
     const startIndex = (page - 1) * limit;
     const endIndex = startIndex + limit;
 
@@ -112,5 +113,27 @@ if (periodo) {
       throw new NotFoundException(`Event with ID "${id}" not found`);
     }
     this.events.splice(eventIndex, 1);
+  }
+
+  getStats(): EventStatsDto {
+    return this.events.reduce(
+      (stats, event) => {
+        const periodo = this.getPeriodFromDate(event.date);
+
+        stats.total += 1;
+        stats[periodo] += 1;
+
+        return stats;
+      },
+      { total: 0, matutino: 0, vespertino: 0, noturno: 0 }
+    );
+  }
+
+  private getPeriodFromDate(date: Date): 'matutino' | 'vespertino' | 'noturno' {
+    const hora = new Date(date).getHours();
+
+    if (hora >= 6 && hora < 12) return 'matutino';
+    if (hora >= 12 && hora < 18) return 'vespertino';
+    return 'noturno';
   }
 }


### PR DESCRIPTION
Com a funcionalidade de filtro por turnos já implementada na main, este PR foca em centralizar as estatísticas de eventos no back-end por meio do endpoint `GET /events/stats`, removendo a necessidade do front-end calcular esses dados na mão.

### O que foi feito?
* Criado o endpoint `GET /events/stats` para retornar os contadores agregados de eventos.
* Criado o contrato `EventStatsDto` para documentação automática no Swagger.
* Implementada a agregação de dados utilizando `.reduce()` para iterar sobre a lista uma única vez (O(n)).

### ✅ Critérios de Aceite Atendidos:
- [x] Rota `/events/stats` retornando `200 OK` no formato `{ total, noturno, matutino, vespertino }`.
- [x] Contadores utilizando exatamente a mesma regra de negócio de horários já aprovada.
- [x] Retorno de todos os contadores zerados (`0`) caso não existam eventos.
- [x] Documentação atualizada no Swagger.
- [x] Testes de Lint.
**Resolve:**
Closes #14 
Closes #20 